### PR TITLE
check for Position > 0 in read_rec()

### DIFF
--- a/deps/ntsort/sort.c
+++ b/deps/ntsort/sort.c
@@ -1418,7 +1418,7 @@ void read_rec()
      * delimiting NULL in the record or beyond), place record in a
      * separate "short" list.
      */
-    if (char_count <= Position)
+    if (Position > 0 && char_count <= Position)
     {
         --Last_recp;
         --Short_recp;


### PR DESCRIPTION
`sort()` asserts that Position is greater than zero if `Short_recp` is less than `End_recp`, but an empty record can allow that condition to be true when `Position` equals zero (because `Position` starts at zero). there are a few conditions for that but the one I tried was two double lines. this PR checks for `Position > 0` along with `char_counter <= Position` in `read_rec`