### PR TITLE
Quote dash-prefixed path arguments in PowerShell wrapper

### DIFF
--- a/src/pwsh-install-template.ps1
+++ b/src/pwsh-install-template.ps1
@@ -169,6 +169,16 @@ function PSConsoleHostReadLine {
             $argsStart = $wordEnd
             # IndexOfAny beats running the regex per arg.
             if ($source.IndexOfAny($script:__COREUTILS_ARG_SPECIAL__) -lt 0) {
+                # PowerShell's Legacy native argument mode can split extension-like
+                # parameter tokens (e.g. -dash.txt -> -dash + .txt) for .cmd
+                # targets. Quote these tokens while leaving ordinary bare globs
+                # unquoted so coreutils can still expand them.
+                if ($source -match '^-[^-][^\s]*\.[^\s]*$' -and
+                    $source.IndexOfAny([char[]]@('*', '?', '[', ']')) -lt 0) {
+                    $rewrittenArgs += "'" + ((__coreutils_q $source).Replace("'", "''")) + "'"
+                    $i++
+                    continue
+                }
                 $rewrittenArgs += $source
                 $i++
                 continue


### PR DESCRIPTION
Fixes one argument-passing edge case from #23.

In the PowerShell wrapper, bare arguments like `-dash.txt` are currently passed through unchanged. For `.cmd` targets running in Legacy native argument mode, PowerShell can split that token as `-dash` and `.txt`.

This change quotes extension-like dash-prefixed bare tokens before handing them to the `.cmd` entry point, while leaving ordinary bare globs unquoted so coreutils can still expand them.

Validated locally with the generated wrapper form:

```powershell
cat -- '"-dash.txt"'
grep foo -- '"-dash.txt"'
cp -- '"-dash.txt"' dash-copy.txt
```

All three commands succeeded against a file named `-dash.txt`.