### PR TITLE
Document PowerShell parser boundaries

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,14 +94,9 @@ Legend: ✅ ships and works · ⚠️ ships but conflicts with a built-in · �
 
 The PowerShell integration rewrites interactive input for common quoting,
 globbing, and alias-conflict cases, but it does not make PowerShell parse input
-like a POSIX shell. Use PowerShell quoting for tokens that would normally be
-backslash-escaped in `sh`:
-
-| POSIX-style input | PowerShell input |
-| ----------------- | ---------------- |
-| `cat space\ name.txt` | `cat 'space name.txt'` |
-| `ls \[ab\].txt` | `ls '[ab].txt'` |
-| `find . \( -name "*.txt" -o -name "*.log" \) -print` | `find . '(' -name "*.txt" -o -name "*.log" ')' -print` |
+like a POSIX shell. Use PowerShell's backtick escape (`` ` ``) instead of
+POSIX-style backslashes, for example ``cat space` name.txt``,
+``ls `[ab`].txt``, or ``find . `( -name "*.txt" -o -name "*.log" `) -print``.
 
 ### Intentionally dropped
 

--- a/README.md
+++ b/README.md
@@ -90,6 +90,19 @@ Legend: ✅ ships and works · ⚠️ ships but conflicts with a built-in · �
 | **File permissions**  | Windows uses ACLs, not POSIX permission bits. Permission-based predicates (for example `find -perm`) may behave differently or be unavailable. |
 | **Symbolic links**    | Reading existing symbolic links works without elevation. Creating new symbolic links requires Developer Mode ([**Settings > System > Advanced**](https://learn.microsoft.com/windows/advanced-settings)) or an elevated terminal. |
 
+### PowerShell parser boundaries
+
+The PowerShell integration rewrites interactive input for common quoting,
+globbing, and alias-conflict cases, but it does not make PowerShell parse input
+like a POSIX shell. Use PowerShell quoting for tokens that would normally be
+backslash-escaped in `sh`:
+
+| POSIX-style input | PowerShell input |
+| ----------------- | ---------------- |
+| `cat space\ name.txt` | `cat 'space name.txt'` |
+| `ls \[ab\].txt` | `ls '[ab].txt'` |
+| `find . \( -name "*.txt" -o -name "*.log" \) -print` | `find . '(' -name "*.txt" -o -name "*.log" ')' -print` |
+
 ### Intentionally dropped
 
 Commands that exist upstream but aren't shipped here because they rely on POSIX-only concepts, would break existing Windows scripts, or simply aren't useful on Windows.

--- a/README.md
+++ b/README.md
@@ -90,13 +90,17 @@ Legend: ✅ ships and works · ⚠️ ships but conflicts with a built-in · �
 | **File permissions**  | Windows uses ACLs, not POSIX permission bits. Permission-based predicates (for example `find -perm`) may behave differently or be unavailable. |
 | **Symbolic links**    | Reading existing symbolic links works without elevation. Creating new symbolic links requires Developer Mode ([**Settings > System > Advanced**](https://learn.microsoft.com/windows/advanced-settings)) or an elevated terminal. |
 
-### PowerShell parser boundaries
+### PowerShell Command Parsing
 
-The PowerShell integration rewrites interactive input for common quoting,
-globbing, and alias-conflict cases, but it does not make PowerShell parse input
-like a POSIX shell. Use PowerShell's backtick escape (`` ` ``) instead of
-POSIX-style backslashes, for example ``cat space` name.txt``,
-``ls `[ab`].txt``, or ``find . `( -name "*.txt" -o -name "*.log" `) -print``.
+The installer integrates itself with interactive PowerShell sessions via `PSReadLine`.
+It ensures that quoted expression behave somewhat like they do under UNIX shells or CMD:
+`echo *.txt` will then print a number of file names, while `echo '*.txt'` will print "*.txt" literally.
+
+There are two shortcomings, however:
+* PowerShell's escape character is still <code>\`</code>, not <code>\\</code><br>
+  While you may write `find . \( -foo -bar \)` with Bash, you still need to write ``find . `( -foo -bar `)`` in PowerShell.
+* `Get-Command ls`, `Get-Help ls`, etc., will still show `ls`, etc., as builtin commands<br>
+  Due to limitations around `PSNativeCommandPreserveBytePipe` we cannot integrate ourselves in a more robust way with PowerShell.
 
 ### Intentionally dropped
 


### PR DESCRIPTION
Adds a short README note for PowerShell integration boundaries.

The wrapper handles common quoting, globbing, and alias-conflict cases, but PowerShell still is not a POSIX shell parser. This documents a few common cases where users should use PowerShell quoting instead of POSIX-style backslash escaping.

This follows up on #23 without trying to solve every shell-compatibility case in the wrapper.