### PR TITLE
Skip PowerShell rewrites when cmd dir is missing

### DIFF
--- a/src/pwsh-install-template.ps1
+++ b/src/pwsh-install-template.ps1
@@ -28,6 +28,8 @@ $script:__COREUTILS_FAST_SKIP__ = [regex]::new(
         [System.Text.RegularExpressions.RegexOptions]::IgnoreCase
 )
 
+$script:__COREUTILS_CMD_DIR__ = '!!CMDDIR!!'
+
 # Casting the scriptblock to Func<Ast,bool> once and reusing it avoids the
 # per-FindAll scriptblock-to-delegate wrapping overhead (~1.7x faster).
 $script:__COREUTILS_CMD_PREDICATE__ = [System.Func[System.Management.Automation.Language.Ast, bool]] {
@@ -104,6 +106,13 @@ function PSConsoleHostReadLine {
 
     # If the line contains no coreutils name, we don't need to parse the AST at all.
     if (-not $script:__COREUTILS_FAST_SKIP__.IsMatch($line)) {
+        return $line
+    }
+
+    # Roamed/synced profiles can load this snippet on machines where coreutils
+    # is not installed. In that case leave the command untouched so PowerShell
+    # can fall back to aliases, functions, PATH, or its normal error handling.
+    if (-not (Test-Path -LiteralPath $script:__COREUTILS_CMD_DIR__ -PathType Container)) {
         return $line
     }
 

--- a/src/pwsh-install-template.ps1
+++ b/src/pwsh-install-template.ps1
@@ -28,8 +28,6 @@ $script:__COREUTILS_FAST_SKIP__ = [regex]::new(
         [System.Text.RegularExpressions.RegexOptions]::IgnoreCase
 )
 
-$script:__COREUTILS_CMD_DIR__ = '!!CMDDIR!!'
-
 # Casting the scriptblock to Func<Ast,bool> once and reusing it avoids the
 # per-FindAll scriptblock-to-delegate wrapping overhead (~1.7x faster).
 $script:__COREUTILS_CMD_PREDICATE__ = [System.Func[System.Management.Automation.Language.Ast, bool]] {
@@ -87,6 +85,9 @@ $script:__COREUTILS_ARG_EVAL__ = [System.Text.RegularExpressions.MatchEvaluator]
     return $ExecutionContext.InvokeCommand.ExpandString($m.Groups[4].Value)
 }
 
+# 0: not tested, 1: coreutils not installed, 2: coreutils installed.
+$script:__COREUTILS_CMD_DIR_TEST__ = 0
+
 # PSConsoleHostReadLine override that rewrites coreutils command names to their
 # .cmd equivalents after PSReadLine returns (history keeps the original).
 #
@@ -109,10 +110,15 @@ function PSConsoleHostReadLine {
         return $line
     }
 
-    # Roamed/synced profiles can load this snippet on machines where coreutils
-    # is not installed. In that case leave the command untouched so PowerShell
-    # can fall back to aliases, functions, PATH, or its normal error handling.
-    if (-not (Test-Path -LiteralPath $script:__COREUTILS_CMD_DIR__ -PathType Container)) {
+    # Roamed/synced profiles can load this snippet on machines where coreutils is not installed.
+    # Test for the existence of the command directory once and remember the result.
+    if ($script:__COREUTILS_CMD_DIR_TEST__ -eq 0) {
+        $script:__COREUTILS_CMD_DIR_TEST__ = 1
+        if (Test-Path -LiteralPath '!!CMDDIR!!' -PathType Container -ErrorAction Ignore) {
+            $script:__COREUTILS_CMD_DIR_TEST__ = 2
+        }
+    }
+    if ($script:__COREUTILS_CMD_DIR_TEST__ -ne 2) {
         return $line
     }
 
@@ -144,7 +150,7 @@ function PSConsoleHostReadLine {
         $cmdElement = $cmd.CommandElements[0]
         $start = $cmdElement.Extent.StartOffset
         $end = $cmdElement.Extent.EndOffset
-        $replacement = "!!CMDPFX!!"
+        $replacement = "& '!!CMDDIR!!"
 
         switch ($baseName) {
             'la' { $replacement += "ls.cmd' --color=auto -AFhl" }

--- a/src/pwsh-install.ps1
+++ b/src/pwsh-install.ps1
@@ -37,8 +37,10 @@ function Remove-FileIfExists([string]$Path) {
 function Get-InjectedSection([string]$CmdDir) {
     $templatePath = Join-Path $PSScriptRoot 'pwsh-install-template.ps1'
     $template = Get-Content -LiteralPath $templatePath -Raw
-    $cmdPfx = "& '" + [System.IO.Path]::GetFullPath($CmdDir).TrimEnd('\') + '\'
+    $cmdDirFull = [System.IO.Path]::GetFullPath($CmdDir).TrimEnd('\')
+    $cmdPfx = "& '" + $cmdDirFull + '\'
     $template = $template.Replace('!!CMDPFX!!', $cmdPfx)
+    $template = $template.Replace('!!CMDDIR!!', $cmdDirFull.Replace("'", "''"))
     $body = $template.TrimEnd("`r", "`n")
     return "$MarkerLine`r`n$body`r`n$MarkerLine"
 }

--- a/src/pwsh-install.ps1
+++ b/src/pwsh-install.ps1
@@ -1,6 +1,9 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 
+# A typical test invocation looks like this (as admin):
+#  .\src\pwsh-install.ps1 -Action Install -Scope CurrentUser -CmdDir 'C:\Program Files\coreutils\cmd'
+
 param(
     [Parameter(Mandatory = $true)]
     [ValidateSet('Install', 'Uninstall')]
@@ -37,10 +40,8 @@ function Remove-FileIfExists([string]$Path) {
 function Get-InjectedSection([string]$CmdDir) {
     $templatePath = Join-Path $PSScriptRoot 'pwsh-install-template.ps1'
     $template = Get-Content -LiteralPath $templatePath -Raw
-    $cmdDirFull = [System.IO.Path]::GetFullPath($CmdDir).TrimEnd('\')
-    $cmdPfx = "& '" + $cmdDirFull + '\'
-    $template = $template.Replace('!!CMDPFX!!', $cmdPfx)
-    $template = $template.Replace('!!CMDDIR!!', $cmdDirFull.Replace("'", "''"))
+    $cmdDir = [System.IO.Path]::GetFullPath($CmdDir).TrimEnd('\') + '\'
+    $template = $template.Replace('!!CMDDIR!!', $cmdDir)
     $body = $template.TrimEnd("`r", "`n")
     return "$MarkerLine`r`n$body`r`n$MarkerLine"
 }


### PR DESCRIPTION
Fixes #27.

The injected PowerShell profile block currently rewrites commands to the installed `cmd` directory unconditionally. If the profile is roamed/synced to a machine where coreutils is not installed, commands such as `ls` are rewritten to a path that does not exist.

This stores the injected command directory in the profile snippet and skips the rewrite when that directory is missing, leaving the original input untouched so PowerShell can fall back to aliases, functions, PATH, or normal error handling.

Validated locally by generating a profile snippet from the template and checking:

- `!!CMDDIR!!` is replaced during injection
- the generated snippet loads successfully
- an existing command directory is detected
- a missing command directory trips the guard path