### PR TITLE
Fix paste omission note

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,7 +35,7 @@ uucore = { path = "deps/coreutils/src/uucore" }
 # * dircolors
 # * expand (conflicts with a DOS command)
 # * more (conflicts with a DOS command; the implementation is also not great right now)
-# * paste (conflicts with a DOS command)
+# * paste (not currently shipped)
 # * shred
 # * vdir (not particularly widely used)
 base32 = { package = "uu_base32", path = "deps/coreutils/src/uu/base32" }

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ Legend: ✅ ships and works · ⚠️ ships but conflicts with a built-in · �
 | `mkdir`    |  ⚠️  |       ⚠️        | |
 | `more`     |  🛑  |       🛑        | Conflicts with the built-in DOS command (consider `edit` as an alternative) |
 | `mv`       |  ✅  |       ⚠️        | |
-| `paste`    |  🛑  |       🛑        | Conflicts with the built-in DOS command |
+| `paste`    |  🛑  |       🛑        | Not currently shipped |
 | `pwd`      |  ✅  |       ⚠️        | |
 | `rm`       |  ✅  |       ⚠️        | |
 | `rmdir`    |  ⚠️  |       ⚠️        | |


### PR DESCRIPTION
Fixes #15.

`paste` is not currently shipped, but the README and Cargo comment said it was omitted because it conflicts with a DOS command. I could not find a Windows/DOS/PowerShell built-in named `paste`, so this updates the wording to avoid claiming a conflict.

I also checked the current local `coreutils.exe --list` output: `paste` is not listed.