### PR TITLE
Clarify PowerShell integration wording

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,13 +92,14 @@ Legend: ✅ ships and works · ⚠️ ships but conflicts with a built-in · �
 ### PowerShell Command Parsing
 
 The installer integrates itself with interactive PowerShell sessions via `PSReadLine`.
-It ensures that quoted expression behave somewhat like they do under UNIX shells or CMD:
+It ensures that quoted expressions behave somewhat like they do under UNIX shells or CMD:
 `echo *.txt` will then print a number of file names, while `echo '*.txt'` will print "*.txt" literally.
 
 There are two shortcomings, however:
 * PowerShell's escape character is still <code>\`</code>, not <code>\\</code><br>
   While you may write `find . \( -foo -bar \)` with Bash, you still need to write ``find . `( -foo -bar `)`` in PowerShell.
-* `Get-Command ls`, `Get-Help ls`, etc., will still show `ls`, etc., as builtin commands<br>
+* The integration rewrites interactive input, but it does not remove PowerShell's aliases<br>
+  `Get-Command ls`, `Get-Help ls`, etc., will still show `ls`, etc., as PowerShell built-ins or aliases.
   Due to limitations around `PSNativeCommandPreserveBytePipe` we cannot integrate ourselves in a more robust way with PowerShell.
 
 ### Intentionally dropped

--- a/coreutils.iss
+++ b/coreutils.iss
@@ -293,7 +293,7 @@ begin
     Description :=
         'Coreutils needs a small profile snippet to work inside PowerShell. ' +
         'Without it, PowerShell mangles argument quoting and globbing, so most Coreutils commands wouldn''t behave correctly. ' +
-        'The snippet also overrides PowerShell''s built-in aliases (cat, cp, ls, ...) so they resolve to the Coreutils versions.' + #13#10#13#10 +
+        'The snippet does not remove PowerShell''s built-in aliases. It rewrites interactive input so names such as cat, cp, and ls resolve to the Coreutils versions.' + #13#10#13#10 +
         'PowerShell 7.4 or newer is required (it requires PSNativeCommandPreserveBytePipe).';
 
     if not g_HasSupportedPowerShellExecutionPolicy then

--- a/src/pwsh-install.ps1
+++ b/src/pwsh-install.ps1
@@ -24,7 +24,7 @@ $SectionMarker = '60b36fc6-2d59-49df-be51-28dd2f4c3c9a'
 $MarkerLine = "# DO NOT MODIFY -- coreutils -- $SectionMarker"
 # Earliest PowerShell that supports PSNativeCommandPreserveBytePipe.
 $MinPwshVersion = [version]'7.4.0'
-# Contains SID --> Microsoft.PowerShell_profile.ps1 mappins,
+# Contains SID --> Microsoft.PowerShell_profile.ps1 mappings,
 # such that we can clean them up on uninstall.
 $ProfilesRegPath = 'HKLM:\SOFTWARE\Microsoft\coreutils\PowerShellProfiles'
 


### PR DESCRIPTION
Clarifies the PowerShell integration wording without changing behavior.

The profile snippet rewrites interactive input through PSReadLine, but it does not remove PowerShell aliases. This updates the README and installer text to avoid implying alias-table changes, and fixes two small typos.