### PR TITLE
Avoid static GetTempPath2 import on pre-Windows 11

### DIFF
--- a/deps/ntsort/sort.c
+++ b/deps/ntsort/sort.c
@@ -1141,7 +1141,7 @@ void init_two_pass()
     if (Temp_dir != NULL)
         _tcscpy_s(temp_path,TEMP_LENGTH,Temp_dir); //modified satyay
     else
-        if ( !GetTempPath2(TEMP_LENGTH - 1, temp_path) ) {
+        if ( !GetTempPath(TEMP_LENGTH - 1, temp_path) ) {
             sys_error(_TEXT("TEMP path"), 0);
         }
     GetTempFileName(temp_path, _TEXT("srt"), 0, Temp_name);


### PR DESCRIPTION
Fixes #49.

`deps/ntsort/sort.c` currently calls `GetTempPath2` directly. That creates a static `GetTempPath2W` import, so `coreutils.exe` can fail to load on Windows versions where that entry point is unavailable.

This switches the `ntsort` temp directory lookup back to `GetTempPath`, which is enough for this old C code path and avoids the pre-Windows 11 load-time failure.

Verification:
- `cargo check --target x86_64-pc-windows-msvc`
- `cargo build --target x86_64-pc-windows-msvc`
- `llvm-objdump -p target\x86_64-pc-windows-msvc\debug\coreutils.exe` shows `GetTempPathW`, but no `GetTempPath2W` static import.
