### PR TITLE
Remove pathchk from the intentionally-dropped list in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ Commands that exist upstream but aren't shipped here because they rely on POSIX-
 * `dd`: Perhaps useful in the future.
 * `dircolors`, `shred`, `sync`, `uname`: Not particularly useful on Windows.
 * `chcon`, `chgrp`, `chmod`, `chown`, `chroot`, `groups`, `hostid`, `id`, `install`,
-  `logname`, `mkfifo`, `mknod`, `nice`, `nohup`, `pathchk`, `pinky`, `runcon`, `stdbuf`,
+  `logname`, `mkfifo`, `mknod`, `nice`, `nohup`, `pinky`, `runcon`, `stdbuf`,
   `stty`, `tty`, `users`, `who`: POSIX-only concepts unavailable on Windows.
 
 <br/>


### PR DESCRIPTION
`pathchk` is shipped: it is declared in `Cargo.toml` (`uu_pathchk`) and is part of the PowerShell integration command set, so it works after install just like the other utilities.

The README's "Intentionally dropped" section, however, lists it among the POSIX-only commands that aren't shipped. This removes `pathchk` from that list so the docs match what actually ships.
