### PR TITLE
Allow GUI install directory selection

### DIFF
--- a/coreutils.iss
+++ b/coreutils.iss
@@ -13,7 +13,6 @@ AppSupportURL=https://github.com/microsoft/coreutils
 AppUpdatesURL=https://github.com/microsoft/coreutils
 SetupMutex=coreutils-windows-setup
 DefaultDirName={autopf}\coreutils
-DisableDirPage=yes
 DisableProgramGroupPage=yes
 SetupIconFile=src\coreutils.ico
 UninstallDisplayIcon={app}\coreutils.exe


### PR DESCRIPTION
The GUI installer currently suppresses the directory selection page, so users cannot choose a non-default install location interactively. This keeps the existing default install path, but lets Inno Setup show its normal directory page.

Fixes #72.