### PR TITLE
Add custom alias creation instructions to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,9 @@ Or grab the latest build from our [Release Page](https://github.com/microsoft/co
 * PowerShell: Set-Alias ll 'ls' or a function in your $PROFILE for arguments, e.g. `function ll { ls -la --color=auto @args }`
 * CMD: doskey ll=ls -la $*
 
+> [!WARNING]
+> Using PowerShell aliases will cause binary stream compatibility. Some utilities will not work when piped (e.g. xargs, find, ...)
+
 ## Shell conflicts
 
 > [!NOTE]

--- a/README.md
+++ b/README.md
@@ -38,6 +38,11 @@ Or grab the latest build from our [Release Page](https://github.com/microsoft/co
 
 <br/>
 
+## Creating custom alias
+
+* PowerShell: Set-Alias ll 'ls' or a function in your $PROFILE for arguments, e.g. `function ll { ls -la --color=auto @args }`
+* CMD: doskey ll=ls -la $*
+
 ## Shell conflicts
 
 > [!NOTE]


### PR DESCRIPTION
* Documentation update in readme:
  * Added a section with examples on how to create custom aliases in PowerShell and CMD, such as defining `ll` as an alias for `ls -la`.

Via https://github.com/microsoft/coreutils/issues/36