### PR TITLE
Fix typos

### DIFF
--- a/deps/ntfind/src/buffer.rs
+++ b/deps/ntfind/src/buffer.rs
@@ -226,9 +226,9 @@ impl BufferStream {
             // find.exe would transparently use memory mapping for `FILE_TYPE_DISK` (see `FILE_STREAM::Initialize`).
             // This doesn't work well with Rust, as we cannot handle the `EXCEPTION_IN_PAGE_ERROR` SEH exception.
             // That's not a problem. ulib is quite poorly written and we can outperform it with `ReadFile` anyway.
-            // `(Rtl)IsTextUnicode` also only inspects the first 256 bytes, so `ReadFile` doesn't loose us anything.
+            // `(Rtl)IsTextUnicode` also only inspects the first 256 bytes, so `ReadFile` doesn't lose us anything.
             //
-            // Why does this matter? Because ulib contains two distinct and separat copies of the `RtlIsTextUnicode`
+            // Why does this matter? Because ulib contains two distinct and separate copies of the `RtlIsTextUnicode`
             // logic and their flags subtly differ. There's no explanation in the code why that is.
             //
             // NOTE that technically ulib also checks the file size and restricts mmap to <3GiB.


### PR DESCRIPTION
I have fixes some typos errors: correct typos in comments in buffer.rs and sort.c