### PR TITLE
Document in README how to list available commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,13 @@ Or grab the latest build from our [Release Page](https://github.com/microsoft/co
 
 <br/>
 
+## Listing available commands
+
+To see the commands made available via Coreutils, use:
+```powershell
+coreutils-manager.exe status
+```
+
 ## Creating custom alias
 
 * PowerShell: Set-Alias ll 'ls' or a function in your $PROFILE for arguments, e.g. `function ll { ls -la --color=auto @args }`


### PR DESCRIPTION
Added section showing how to use coreutils-manager to list the available Coreutils commands. It's not obvious that one could this.

While there is [an issue](https://github.com/microsoft/coreutils/issues/121) proposing listing them IN the readme (which has been met with debate), it seems that showing users how they can "do it once installed" could be helpful to many. (Sometimes "it's the little things".)