### PR TITLE
Update README with Coreutils command check

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,13 @@ Legend: ✅ ships and works · ⚠️ ships but conflicts with a built-in · �
 | `uptime`   |  ✅  |       ⚠️        | |
 | `whoami`   |  🛑  |       🛑        | Conflicts with the built-in Windows command |
 
+### Determining when a command is a Coreutils command
+
+To check if a command is provided by Coreutils (versus being built-into Windows), use the `--version` argument. When  used with a Coreutils command, this will indicate its version. For example, `ls --version`, could respond:
+
+```
+ls (uutils coreutils) 0.8.0
+```
 <br/>
 
 ## Windows caveats


### PR DESCRIPTION
Added section on determining if a command is a Coreutils commands, using its available --version argument.

Folks can end up wondering if a given command is one provided by Coreutils or might be a built-in Windows one. I've proposed this as a brief subsection below that on potential conflicts (and of there are [some issues](https://github.com/microsoft/coreutils/issues/113) on the matter.