### PR TITLE
Add monthly Dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -24,6 +24,15 @@ updates:
           - "minor"
           - "patch"
 
+  - package-ecosystem: "gitsubmodule"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+    groups:
+      submodule-updates:
+        patterns:
+          - "*"
+
   - package-ecosystem: "nuget"
     directory: "/.pipelines"
     schedule:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,37 @@
+version: 2
+updates:
+  - package-ecosystem: "cargo"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+    groups:
+      minor-and-patch:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"
+
+  - package-ecosystem: "cargo"
+    directory: "/deps/ntfind"
+    schedule:
+      interval: "monthly"
+    groups:
+      minor-and-patch:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"
+
+  - package-ecosystem: "nuget"
+    directory: "/.pipelines"
+    schedule:
+      interval: "monthly"
+    groups:
+      minor-and-patch:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"


### PR DESCRIPTION
## Summary

- Run monthly Dependabot checks for the root Cargo manifest and `deps/ntfind`.
- Run monthly checks for the three Git submodules and `.pipelines/packages.config`.
- Group Cargo and NuGet minor and patch updates while leaving major updates separate. Group submodule commit updates without semantic version categories.

## Validation

- Validated `.github/dependabot.yml` against the Dependabot 2.0 SchemaStore schema.
- Confirmed all three pinned submodule commits exist. The `deps/coreutils` pin and `microsoft/uutils-coreutils/main` have diverged: main is 976 commits ahead, and the pinned side is 10 commits ahead.
- Confirmed every configured directory contains the expected manifest.
- Confirmed the pull request changes only `.github/dependabot.yml`.
